### PR TITLE
remove feature with bypassing time

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # Anti-testportal
 
-Minimalistic Chrome extension - bypass for blur check and time limit on testportal.pl(net).
+Minimalistic Chrome extension - bypass for blur check on testportal.pl(net).
 
-🈹🐀💥 Changing pages will not display a warning about leaving the page. After the time for answering the question (or completing the test) has elapsed, nothing will happen - you can still answer the questions!
+🈹🐀💥 Changing pages will not display a warning about leaving the page.
+
+❌ ~~After the time for answering the question (or completing the test) has elapsed, nothing will happen - you can still answer the questions!~~
+This feature currently doesn't work
 
 [![forthebadge](https://forthebadge.com/images/badges/made-with-typescript.svg)](https://forthebadge.com)
 

--- a/src/bypass.ts
+++ b/src/bypass.ts
@@ -8,7 +8,4 @@ export default () => {
 
   // Lumm1t is not defined, ignore all errors.
   window.onerror = (): boolean => true;
-
-  // Set (almost) unlimited time for each question.
-  startTime = Date.parse('January 1, 2070 00:00:00 UTC') as number;
 };


### PR DESCRIPTION
https://github.com/Lumm1t/anti-testportal/issues/12

it didn't worked, tesportal started calculating time on their side, no idea if its bypassable.